### PR TITLE
Was added translations to all vendor types.

### DIFF
--- a/FromLocalsToLocals/Resources/Views/Home/Index.lt.resx
+++ b/FromLocalsToLocals/Resources/Views/Home/Index.lt.resx
@@ -117,17 +117,38 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Beverages" xml:space="preserve">
+    <value>Gėrimai</value>
+  </data>
+  <data name="CarRepair" xml:space="preserve">
+    <value>Autoservisas</value>
+  </data>
+  <data name="Clothing" xml:space="preserve">
+    <value>Apranga</value>
+  </data>
   <data name="Discover" xml:space="preserve">
     <value>Atrask</value>
   </data>
   <data name="Discover all nearby vendors with just a few clicks." xml:space="preserve">
     <value>Atrask artimiausius pardavėjus keliais mygtuko paspaudimais.</value>
   </data>
+  <data name="Electronics" xml:space="preserve">
+    <value>Elektronika</value>
+  </data>
   <data name="Experience all the finest products around you." xml:space="preserve">
     <value>Atrask geriausius tave supančius produktus.</value>
   </data>
+  <data name="Flowers" xml:space="preserve">
+    <value>Gėlių salonas</value>
+  </data>
   <data name="Follow" xml:space="preserve">
     <value>Sekti</value>
+  </data>
+  <data name="Food" xml:space="preserve">
+    <value>Maistas</value>
+  </data>
+  <data name="Footwear" xml:space="preserve">
+    <value>Avalynė</value>
   </data>
   <data name="Go" xml:space="preserve">
     <value>Pirmyn</value>
@@ -138,14 +159,17 @@
   <data name="Join" xml:space="preserve">
     <value>Registracija</value>
   </data>
+  <data name="Music" xml:space="preserve">
+    <value>Muzikos prekės</value>
+  </data>
   <data name="No reviews" xml:space="preserve">
     <value>Atsiliepimų nėra</value>
   </data>
+  <data name="Other" xml:space="preserve">
+    <value>Kita</value>
+  </data>
   <data name="Read More" xml:space="preserve">
     <value>Plačiau</value>
-  </data>
-  <data name="Reviews" xml:space="preserve">
-    <value>Atsiliepimai</value>
   </data>
   <data name="Reviews" xml:space="preserve">
     <value>Apžvalgos</value>
@@ -153,11 +177,20 @@
   <data name="Rural tourism" xml:space="preserve">
     <value>Kaimo turizmas</value>
   </data>
+  <data name="RuralTourism" xml:space="preserve">
+    <value>Kaimo turizmas</value>
+  </data>
+  <data name="Stationery" xml:space="preserve">
+    <value>Kanceliarinės prekės</value>
+  </data>
   <data name="Support your local sellers" xml:space="preserve">
     <value>Palaikyk vietinius pardavėjus</value>
   </data>
   <data name="The Most Popular Services" xml:space="preserve">
     <value>Populiariausios paslaugos</value>
+  </data>
+  <data name="Toys" xml:space="preserve">
+    <value>Žaislai</value>
   </data>
   <data name="Unfollow" xml:space="preserve">
     <value>Nebesekti</value>

--- a/FromLocalsToLocals/Resources/Views/Home/Index.resx
+++ b/FromLocalsToLocals/Resources/Views/Home/Index.resx
@@ -117,64 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Add a service" xml:space="preserve">
-    <value>Pridėti paslaugą</value>
-  </data>
-  <data name="Are you sure you want to delete" xml:space="preserve">
-    <value>Ar jus tikrai norite pašalinti</value>
-  </data>
-  <data name="Beverages" xml:space="preserve">
-    <value>Gėrimai</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Atšaukti</value>
-  </data>
   <data name="CarRepair" xml:space="preserve">
-    <value>Autoservisas</value>
-  </data>
-  <data name="Clothing" xml:space="preserve">
-    <value>Apranga</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>Panaikinti</value>
-  </data>
-  <data name="Details" xml:space="preserve">
-    <value>Detalės</value>
-  </data>
-  <data name="Edit" xml:space="preserve">
-    <value>Redaguoti</value>
-  </data>
-  <data name="Electronics" xml:space="preserve">
-    <value>Elektronika</value>
-  </data>
-  <data name="Flowers" xml:space="preserve">
-    <value>Gėlių salonas</value>
-  </data>
-  <data name="Food" xml:space="preserve">
-    <value>Maistas</value>
-  </data>
-  <data name="Footwear" xml:space="preserve">
-    <value>Avalynė</value>
-  </data>
-  <data name="Music" xml:space="preserve">
-    <value>Muzikos prekės</value>
-  </data>
-  <data name="My Services" xml:space="preserve">
-    <value>Mano paslaugos</value>
-  </data>
-  <data name="MyVendors" xml:space="preserve">
-    <value>ManoPaslaugos</value>
-  </data>
-  <data name="Other" xml:space="preserve">
-    <value>Kita</value>
+    <value>Car repair</value>
   </data>
   <data name="RuralTourism" xml:space="preserve">
-    <value>Kaimo turizmas</value>
-  </data>
-  <data name="Stationery" xml:space="preserve">
-    <value>Kanceliarinės prekės</value>
-  </data>
-  <data name="Toys" xml:space="preserve">
-    <value>Žaislai</value>
+    <value>Rural tourism</value>
   </data>
 </root>

--- a/FromLocalsToLocals/Resources/Views/Vendors/AllVendors.lt.resx
+++ b/FromLocalsToLocals/Resources/Views/Vendors/AllVendors.lt.resx
@@ -123,11 +123,23 @@
   <data name="All Services" xml:space="preserve">
     <value>Visos paslaugos</value>
   </data>
+  <data name="Beverages" xml:space="preserve">
+    <value>Gėrimai</value>
+  </data>
   <data name="But there might be some soon!" xml:space="preserve">
     <value>Turėtų greitu laiku atsirasti!</value>
   </data>
   <data name="Car repair" xml:space="preserve">
     <value>Servisas</value>
+  </data>
+  <data name="CarRepair" xml:space="preserve">
+    <value>Autoservisas</value>
+  </data>
+  <data name="Clothing" xml:space="preserve">
+    <value>Apranga</value>
+  </data>
+  <data name="Electronics" xml:space="preserve">
+    <value>Elektronika</value>
   </data>
   <data name="Experience all the finest products around you" xml:space="preserve">
     <value>Atrask geriausius tave supančius produktus</value>
@@ -138,11 +150,23 @@
   <data name="Filters" xml:space="preserve">
     <value>Filtrai</value>
   </data>
+  <data name="Flowers" xml:space="preserve">
+    <value>Gėlių salonas</value>
+  </data>
   <data name="Follow" xml:space="preserve">
     <value>Sekti</value>
   </data>
+  <data name="Food" xml:space="preserve">
+    <value>Maistas</value>
+  </data>
+  <data name="Footwear" xml:space="preserve">
+    <value>Avalynė</value>
+  </data>
   <data name="Items per page:" xml:space="preserve">
     <value>Elementų puslapyje</value>
+  </data>
+  <data name="Music" xml:space="preserve">
+    <value>Muzikos prekės</value>
   </data>
   <data name="New Services" xml:space="preserve">
     <value>Naujos paslaugos</value>
@@ -152,6 +176,9 @@
   </data>
   <data name="No Reviews" xml:space="preserve">
     <value>Atsiliepimų nėra</value>
+  </data>
+  <data name="Other" xml:space="preserve">
+    <value>Kita</value>
   </data>
   <data name="Random" xml:space="preserve">
     <value>Atsitiktinai</value>
@@ -165,11 +192,20 @@
   <data name="Rural tourism" xml:space="preserve">
     <value>Kaimo turizmas</value>
   </data>
+  <data name="RuralTourism" xml:space="preserve">
+    <value>Kaimo turizmas</value>
+  </data>
   <data name="Services in the past month registered on our site" xml:space="preserve">
     <value>Šį mėnesį užregistruotos paslaugos</value>
   </data>
+  <data name="Stationery" xml:space="preserve">
+    <value>Kanceliarinės prekės</value>
+  </data>
   <data name="Title" xml:space="preserve">
     <value>Pavadinimas</value>
+  </data>
+  <data name="Toys" xml:space="preserve">
+    <value>Žaislai</value>
   </data>
   <data name="Unfollow" xml:space="preserve">
     <value>Nebesekti</value>

--- a/FromLocalsToLocals/Resources/Views/Vendors/AllVendors.resx
+++ b/FromLocalsToLocals/Resources/Views/Vendors/AllVendors.resx
@@ -117,64 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Add a service" xml:space="preserve">
-    <value>Pridėti paslaugą</value>
-  </data>
-  <data name="Are you sure you want to delete" xml:space="preserve">
-    <value>Ar jus tikrai norite pašalinti</value>
-  </data>
-  <data name="Beverages" xml:space="preserve">
-    <value>Gėrimai</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Atšaukti</value>
-  </data>
   <data name="CarRepair" xml:space="preserve">
-    <value>Autoservisas</value>
-  </data>
-  <data name="Clothing" xml:space="preserve">
-    <value>Apranga</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>Panaikinti</value>
-  </data>
-  <data name="Details" xml:space="preserve">
-    <value>Detalės</value>
-  </data>
-  <data name="Edit" xml:space="preserve">
-    <value>Redaguoti</value>
-  </data>
-  <data name="Electronics" xml:space="preserve">
-    <value>Elektronika</value>
-  </data>
-  <data name="Flowers" xml:space="preserve">
-    <value>Gėlių salonas</value>
-  </data>
-  <data name="Food" xml:space="preserve">
-    <value>Maistas</value>
-  </data>
-  <data name="Footwear" xml:space="preserve">
-    <value>Avalynė</value>
-  </data>
-  <data name="Music" xml:space="preserve">
-    <value>Muzikos prekės</value>
-  </data>
-  <data name="My Services" xml:space="preserve">
-    <value>Mano paslaugos</value>
-  </data>
-  <data name="MyVendors" xml:space="preserve">
-    <value>ManoPaslaugos</value>
-  </data>
-  <data name="Other" xml:space="preserve">
-    <value>Kita</value>
+    <value>Car repair</value>
   </data>
   <data name="RuralTourism" xml:space="preserve">
-    <value>Kaimo turizmas</value>
-  </data>
-  <data name="Stationery" xml:space="preserve">
-    <value>Kanceliarinės prekės</value>
-  </data>
-  <data name="Toys" xml:space="preserve">
-    <value>Žaislai</value>
+    <value>Rural tourism</value>
   </data>
 </root>

--- a/FromLocalsToLocals/Resources/Views/Vendors/Details.lt.resx
+++ b/FromLocalsToLocals/Resources/Views/Vendors/Details.lt.resx
@@ -123,20 +123,41 @@
   <data name="Address:&amp;nbsp;" xml:space="preserve">
     <value>Adresas:&amp;nbsp;</value>
   </data>
+  <data name="Beverages" xml:space="preserve">
+    <value>Gėrimai</value>
+  </data>
   <data name="Car repair" xml:space="preserve">
     <value>Servisas</value>
+  </data>
+  <data name="CarRepair" xml:space="preserve">
+    <value>Autoservisas</value>
   </data>
   <data name="Closed" xml:space="preserve">
     <value>Nedirbame</value>
   </data>
+  <data name="Clothing" xml:space="preserve">
+    <value>Apranga</value>
+  </data>
   <data name="Details" xml:space="preserve">
     <value>Detalės</value>
+  </data>
+  <data name="Electronics" xml:space="preserve">
+    <value>Elektronika</value>
+  </data>
+  <data name="Flowers" xml:space="preserve">
+    <value>Gėlių salonas</value>
   </data>
   <data name="Follow" xml:space="preserve">
     <value>Sekti</value>
   </data>
   <data name="Followers" xml:space="preserve">
     <value>Sekėjų</value>
+  </data>
+  <data name="Food" xml:space="preserve">
+    <value>Maistas</value>
+  </data>
+  <data name="Footwear" xml:space="preserve">
+    <value>Avalynė</value>
   </data>
   <data name="Friday" xml:space="preserve">
     <value>Penktadieniais</value>
@@ -147,14 +168,23 @@
   <data name="Monday" xml:space="preserve">
     <value>Pirmadieniais</value>
   </data>
+  <data name="Music" xml:space="preserve">
+    <value>Muzikos prekės</value>
+  </data>
   <data name="News Feed" xml:space="preserve">
     <value>Naujienos</value>
   </data>
   <data name="No description provided" xml:space="preserve">
     <value>Aprašymo nėra</value>
   </data>
+  <data name="Other" xml:space="preserve">
+    <value>Kita</value>
+  </data>
   <data name="Reviews" xml:space="preserve">
     <value>Atsiliepimai</value>
+  </data>
+  <data name="RuralTourism" xml:space="preserve">
+    <value>Kaimo turizmas</value>
   </data>
   <data name="Saturday" xml:space="preserve">
     <value>Šeštadieniais</value>
@@ -162,11 +192,17 @@
   <data name="Service registered | " xml:space="preserve">
     <value>Paslauga užregistruota | </value>
   </data>
+  <data name="Stationery" xml:space="preserve">
+    <value>Kanceliarinės prekės</value>
+  </data>
   <data name="Sunday" xml:space="preserve">
     <value>Sekmadieniais</value>
   </data>
   <data name="Thursday" xml:space="preserve">
     <value>Ketvirtadieniais</value>
+  </data>
+  <data name="Toys" xml:space="preserve">
+    <value>Žaislai</value>
   </data>
   <data name="Tuesday" xml:space="preserve">
     <value>Antradieniais</value>

--- a/FromLocalsToLocals/Resources/Views/Vendors/Details.resx
+++ b/FromLocalsToLocals/Resources/Views/Vendors/Details.resx
@@ -117,64 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Add a service" xml:space="preserve">
-    <value>Pridėti paslaugą</value>
-  </data>
-  <data name="Are you sure you want to delete" xml:space="preserve">
-    <value>Ar jus tikrai norite pašalinti</value>
-  </data>
-  <data name="Beverages" xml:space="preserve">
-    <value>Gėrimai</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Atšaukti</value>
-  </data>
   <data name="CarRepair" xml:space="preserve">
-    <value>Autoservisas</value>
-  </data>
-  <data name="Clothing" xml:space="preserve">
-    <value>Apranga</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>Panaikinti</value>
-  </data>
-  <data name="Details" xml:space="preserve">
-    <value>Detalės</value>
-  </data>
-  <data name="Edit" xml:space="preserve">
-    <value>Redaguoti</value>
-  </data>
-  <data name="Electronics" xml:space="preserve">
-    <value>Elektronika</value>
-  </data>
-  <data name="Flowers" xml:space="preserve">
-    <value>Gėlių salonas</value>
-  </data>
-  <data name="Food" xml:space="preserve">
-    <value>Maistas</value>
-  </data>
-  <data name="Footwear" xml:space="preserve">
-    <value>Avalynė</value>
-  </data>
-  <data name="Music" xml:space="preserve">
-    <value>Muzikos prekės</value>
-  </data>
-  <data name="My Services" xml:space="preserve">
-    <value>Mano paslaugos</value>
-  </data>
-  <data name="MyVendors" xml:space="preserve">
-    <value>ManoPaslaugos</value>
-  </data>
-  <data name="Other" xml:space="preserve">
-    <value>Kita</value>
+    <value>Car repair</value>
   </data>
   <data name="RuralTourism" xml:space="preserve">
-    <value>Kaimo turizmas</value>
-  </data>
-  <data name="Stationery" xml:space="preserve">
-    <value>Kanceliarinės prekės</value>
-  </data>
-  <data name="Toys" xml:space="preserve">
-    <value>Žaislai</value>
+    <value>Rural tourism</value>
   </data>
 </root>

--- a/FromLocalsToLocals/Resources/Views/Vendors/MyVendors.resx
+++ b/FromLocalsToLocals/Resources/Views/Vendors/MyVendors.resx
@@ -117,64 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Add a service" xml:space="preserve">
-    <value>Pridėti paslaugą</value>
-  </data>
-  <data name="Are you sure you want to delete" xml:space="preserve">
-    <value>Ar jus tikrai norite pašalinti</value>
-  </data>
-  <data name="Beverages" xml:space="preserve">
-    <value>Gėrimai</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Atšaukti</value>
-  </data>
   <data name="CarRepair" xml:space="preserve">
-    <value>Autoservisas</value>
-  </data>
-  <data name="Clothing" xml:space="preserve">
-    <value>Apranga</value>
-  </data>
-  <data name="Delete" xml:space="preserve">
-    <value>Panaikinti</value>
-  </data>
-  <data name="Details" xml:space="preserve">
-    <value>Detalės</value>
-  </data>
-  <data name="Edit" xml:space="preserve">
-    <value>Redaguoti</value>
-  </data>
-  <data name="Electronics" xml:space="preserve">
-    <value>Elektronika</value>
-  </data>
-  <data name="Flowers" xml:space="preserve">
-    <value>Gėlių salonas</value>
-  </data>
-  <data name="Food" xml:space="preserve">
-    <value>Maistas</value>
-  </data>
-  <data name="Footwear" xml:space="preserve">
-    <value>Avalynė</value>
-  </data>
-  <data name="Music" xml:space="preserve">
-    <value>Muzikos prekės</value>
-  </data>
-  <data name="My Services" xml:space="preserve">
-    <value>Mano paslaugos</value>
-  </data>
-  <data name="MyVendors" xml:space="preserve">
-    <value>ManoPaslaugos</value>
-  </data>
-  <data name="Other" xml:space="preserve">
-    <value>Kita</value>
+    <value>Car repair</value>
   </data>
   <data name="RuralTourism" xml:space="preserve">
-    <value>Kaimo turizmas</value>
-  </data>
-  <data name="Stationery" xml:space="preserve">
-    <value>Kanceliarinės prekės</value>
-  </data>
-  <data name="Toys" xml:space="preserve">
-    <value>Žaislai</value>
+    <value>Rural tourism</value>
   </data>
 </root>

--- a/FromLocalsToLocals/Views/Home/Index.cshtml
+++ b/FromLocalsToLocals/Views/Home/Index.cshtml
@@ -73,17 +73,7 @@
                         <div class="card-body">
                             <h5 class="card-title" style="margin:0px;">@item.Title</h5>
                             <hr />
-                            @switch (item.VendorTypeDb)
-                            {
-                                case "CarRepair":<p class="text-muted text-uppercase">@_localizer["Car repair"]</p>
-                                break;
-
-                            case "RuralTourism":<p class="text-muted text-uppercase">Rural tourism</p>
-                                break;
-
-                            default: <p class="text-muted text-uppercase">@item.VendorTypeDb</p>
-                            break;
-                    }
+                            <p class="text-muted text-uppercase">@item.VendorTypeDb</p>
                             <hr />
                             @if (item.ReviewsCount.Sum() == 0)
                             {

--- a/FromLocalsToLocals/Views/Vendors/AllVendors.cshtml
+++ b/FromLocalsToLocals/Views/Vendors/AllVendors.cshtml
@@ -64,17 +64,7 @@ else
                     <div class="card-body">
                         <h5 class="card-title" style="margin:0px;">@vendor.Title</h5>
                         <hr />
-                        @switch (vendor.VendorTypeDb)
-                        {
-                            case "CarRepair":<p class="text-muted text-uppercase">@_localizer["Car repair"]</p>
-                            break;
-
-                        case "RuralTourism":<p class="text-muted text-uppercase">@_localizer["Rural tourism"]</p>
-                        break;
-
-                    default: <p class="text-muted text-uppercase">@vendor.VendorTypeDb</p>
-                    break;
-            }
+                        <p class="text-muted text-uppercase">@_localizer[@vendor.VendorTypeDb]</p>
                         <hr />
                         @if (vendor.ReviewsCount.Sum() == 0)
                         {
@@ -206,17 +196,7 @@ else
                         <div class="card-body">
                             <h5 class="card-title" style="margin:0px;">@Model.Vendors[i * itemsInRow + j].Title</h5>
                             <hr />
-                            @switch (Model.Vendors[i * itemsInRow + j].VendorTypeDb)
-                            {
-                                case "CarRepair":<p class="text-muted text-uppercase">@_localizer["Car repair"]</p>
-                                break;
-
-                            case "RuralTourism":<p class="text-muted text-uppercase">@_localizer["Rural tourism"]</p>
-                            break;
-
-                        default: <p class="text-muted text-uppercase">@Model.Vendors[i * itemsInRow + j].VendorTypeDb</p>
-                        break;
-                }
+                            <p class="text-muted text-uppercase">@_localizer[@Model.Vendors[i * itemsInRow + j].VendorTypeDb]</p>
                             <hr />
                             @if (Model.Vendors[i * itemsInRow + j].ReviewsCount.Sum() == 0)
                             {

--- a/FromLocalsToLocals/Views/Vendors/Details.cshtml
+++ b/FromLocalsToLocals/Views/Vendors/Details.cshtml
@@ -37,17 +37,7 @@
             <div class="row">
                 <div class="col-9">
                     <div class="row">
-                        @switch (Model.VendorType)
-                        {
-                            case FromLocalsToLocals.Utilities.VendorType.CarRepair:<p class="text-muted text-uppercase">@_localizer["Car repair"]</p>
-                            break;
-
-                        case FromLocalsToLocals.Utilities.VendorType.RuralTourism:<p class="text-muted text-uppercase">Rural tourism</p>
-                            break;
-
-                        default: <p class="text-muted text-uppercase">@Model.VendorType</p>
-                        break;
-                }
+                        <p class="text-muted text-uppercase">@_localizer[@Model.VendorTypeDb]</p>
                     </div>
                     <div class="row" style="margin-top: -15px;">
                         <h2>@Model.Title</h2>

--- a/FromLocalsToLocals/Views/Vendors/MyVendors.cshtml
+++ b/FromLocalsToLocals/Views/Vendors/MyVendors.cshtml
@@ -37,23 +37,9 @@
                 <td class="text-center">
                     @Html.DisplayFor(modelItem => item.Address)
                 </td>
-
-                @switch (item.VendorTypeDb)
-                {
-                    case "CarRepair":
-                        <td class="text-center">Car Repair</td>
-                        break;
-
-                    case "RuralTourism":
-                        <td class="text-center">Rural Tourism</td>
-                        break;
-
-                    default:
-                        <td class="text-center">
-                            @Html.DisplayFor(modelItem => item.VendorTypeDb)
-                        </td>
-                        break;
-                }
+                <td class="text-center">
+                    @_localizer[@item.VendorTypeDb]
+                </td>
                 <td class="text-center">
                     <a asp-action="Edit" asp-route-id="@item.ID">@_localizer["Edit"]</a> |
                     <a asp-action="Details" asp-route-id="@item.ID">@_localizer["Details"]</a> |


### PR DESCRIPTION
Now vendors types are translated to Lithuanian language. It looks like:
My services/Mano paslaugos:
![Screenshot (135)](https://user-images.githubusercontent.com/55496840/102868106-6f411a80-4442-11eb-8f97-803df02ed131.png)
![Screenshot (133)](https://user-images.githubusercontent.com/55496840/102868115-72d4a180-4442-11eb-8a6c-2a55bb8480ed.png)
New services/Naujos paslaugos:
![Screenshot (141)](https://user-images.githubusercontent.com/55496840/102868176-8849cb80-4442-11eb-9a61-8bdb1306c9e9.png)
![Screenshot (140)](https://user-images.githubusercontent.com/55496840/102868182-8aac2580-4442-11eb-853b-8d40dfd5ea10.png)
Vendor details/Plačiau apie pardavėją:
![Screenshot (142)](https://user-images.githubusercontent.com/55496840/102868239-9b5c9b80-4442-11eb-8f65-7fca84302907.png)
![Screenshot (143)](https://user-images.githubusercontent.com/55496840/102868246-9dbef580-4442-11eb-8772-2cd2e2891a71.png)

